### PR TITLE
GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Assignment: Graphql
+**Notice**: You can find GQL requests collection for Postman in root of this project `node-graphql.postman_collection.json`.
 ### Tasks:
 1. Add logic to the restful endpoints (users, posts, profiles, member-types folders in ./src/routes).  
    1.1. npm run test - 100%  

--- a/node-graphql.postman_collection.json
+++ b/node-graphql.postman_collection.json
@@ -1,0 +1,452 @@
+{
+	"info": {
+		"_postman_id": "f22155e2-7995-4628-8910-77fcf08346ab",
+		"name": "node-graphql",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "19569509"
+	},
+	"item": [
+		{
+			"name": "2.1",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query {\n  memberTypes {id}\n  posts {id}\n  profiles {id}\n  users {id}\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.2",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query($memberTypeId: String!, $postId: String!, $profileId: String!, $userId: String!) {\n  memberType(id: $memberTypeId) {id}\n  post(id: $postId) {id}\n  profile(id: $profileId) {id}\n  user(id: $userId) {id}\n}",
+						"variables": "{\n  \"memberTypeId\": \"basic\",\n  \"postId\": \"\", \n  \"profileId\": \"\", \n  \"userId\": \"\"\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.3",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query {\n  users {\n    id\n    posts {id}\n    profile {id}\n    memberType {id}\n  }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.4",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query($id: String!) {\n  user(id: $id) {\n    id\n    firstName\n    lastName\n    email\n    subscribedToUserIds\n    posts {\n      id\n      title\n      content\n    }\n    profile {\n      id\n      avatar\n      sex\n      birthday\n      country\n      street\n      city\n    }\n    memberType {\n      id\n      discount\n      monthPostsLimit\n    }\n  }\n}",
+						"variables": "{\n  \"id\":  \"\"\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.5",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query {\n  users {\n    id\n    userSubscribedTo {id}\n    profile {id}\n  }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.6",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query($id: String!) {\n  user(id: $id) {\n    id\n    subscribedToUser {id}\n    posts {id}\n  }\n}",
+						"variables": "{\n  \"id\": \"\"\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.7",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "query {\n  users {\n    id\n    userSubscribedTo {\n      id\n      userSubscribedTo {id}\n      subscribedToUser {id}\n    }\n    subscribedToUser {\n      id\n      userSubscribedTo {id}\n      subscribedToUser {id}\n    }\n  }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.8",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($user: CreateUserInput!) {\n  createUser(user: $user) {\n    id\n    firstName\n    lastName\n    email\n    subscribedToUserIds\n  }\n}",
+						"variables": "{\n  \"user\": {\n    \"firstName\": \"Frances\",\n    \"lastName\": \"Hudson\",\n    \"email\": \"Carleton_Monahan@gmail.com\"\n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.9",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($profile: CreateProfileInput!) {\n  createProfile(profile: $profile) {\n    id\n    avatar\n    sex\n    birthday\n    country\n    street\n    city\n    userId\n    memberTypeId\n  }\n}",
+						"variables": "{\n  \"profile\": {\n    \"userId\": \"\",\n    \"memberTypeId\": \"basic\",\n    \"avatar\": \n\"https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/758.jpg\",\n    \"sex\": \"female\",\n    \"birthday\": 1200784,\n    \"country\": \"Cyprus\",\n    \"street\": \"Wilber Villages\",\n    \"city\": \"Beavercreek\"\n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.10",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($post: CreatePostInput!) {\n  createPost(post: $post) {\n    id\n    userId\n    title\n    content\n  }\n}",
+						"variables": "{\n  \"post\": {\n    \"userId\": \"\",\n    \"title\": \"2_Beatae doloremque nemo aperiam culpa neque dolore reiciendis.\",\n    \"content\": \"Eligendi pariatur aspernatur nam. Animi beatae deleniti ducimus id numquam\\nquidem eligendi. Dolor eius est. Incidunt atque cum velit sit nam commodi. Repudiandae alias ratione similique sunt.\"\n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.12",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($id: ID!, $user: UpdateUserInput!) {\n  updateUser(id: $id, user: $user) {\n    id\n    firstName\n    lastName\n    email\n    subscribedToUserIds\n  }\n}",
+						"variables": "{\n  \"id\": \"\",\n  \"user\": {\n    \"firstName\": \"Leonor\",\n    \"lastName\": \"Leannon\",\n    \"email\": \"Glen.Huel58@yahoo.com\"\n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.13",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($id: ID!, $profile: UpdateProfileInput!) {\n  updateProfile(id: $id, profile: $profile) {\n    id\n    avatar\n    sex\n    birthday\n    country\n    street\n    city\n    userId\n    memberTypeId\n  }\n}",
+						"variables": "{\n  \"id\": \"\",\n  \"profile\": {\n    \"memberTypeId\": \"basic\",\n    \"avatar\": \n\"https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/758.jpg\",\n    \"sex\": \"female\",\n    \"birthday\": 1200784,\n    \"country\": \"Istambul\",\n    \"street\": \"Wilber Villages\",\n    \"city\": \"Beavercreek\"\n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.14",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($id: ID!, $post: UpdatePostInput!) {\n  updatePost(id: $id, post: $post) {\n    id\n    userId\n    title\n    content\n  }\n}",
+						"variables": "{\n  \"id\": \"\",\n  \"post\": {\n    \"title\": \"Laborum possimus sed.\",\n    \"content\": \"Pariatur eum quisquam distinctio perferendis molestias illo quam. Quos id\\ncumque atque suscipit maiores. Mollitia eaque maxime omnis. Esse vitae deleniti consectetur natus. Harum temporibus\\nvelit aperiam.\" \n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.15",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($id: ID!, $memberType: UpdateMemberTypeInput!) {\n  updateMemberType(id: $id, memberType: $memberType) {\n    id\n    discount        \n    monthPostsLimit\n  }\n}",
+						"variables": "{\n  \"id\": \"basic\",\n  \"memberType\": {\n    \"discount\": 10,\n    \"monthPostsLimit\": 50\n  }\n}\n"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.16 subscribe to",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($id: ID!, $subscribeToUser: UserIdInput!) {\n  subscribeTo(id: $id, subscribeToUser: $subscribeToUser){\n   id\n   subscribedToUserIds\n  }\n}",
+						"variables": "{\n  \"id\": \"\",\n  \"subscribeToUser\": {\n    \"id\": \"\"\n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "2.16 unsubscribe from",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "mutation ($id: ID!, $unsubscribeFromUser: UserIdInput!) {\n  unsubscribeFrom(id: $id, unsubscribeFromUser: $unsubscribeFromUser){\n   id\n   subscribedToUserIds\n  }\n}",
+						"variables": "{\n  \"id\": \"\",\n  \"unsubscribeFromUser\": {\n    \"id\": \"\"\n  }\n}"
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Users ID",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "graphql",
+					"graphql": {
+						"query": "{\n  users {\n    id\n  }\n}",
+						"variables": ""
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/graphql",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"graphql"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -18,10 +18,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         query: rootQuery,
       });
       const source = request.body.query || request.body.mutation || '';
-      // const variableValues = request.body.variables || {};
+      const variableValues = request.body.variables || {};
       const contextValue = fastify;
 
-      return await graphql({ schema, source, contextValue });
+      return await graphql({ schema, source, variableValues, contextValue });
     },
   );
 };

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
 import { graphql, GraphQLSchema } from 'graphql';
+import { rootMutation } from './mutation';
 import { rootQuery } from './query';
 import { graphqlBodySchema } from './schema';
 
@@ -16,6 +17,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     async function (request, reply) {
       const schema = new GraphQLSchema({
         query: rootQuery,
+        mutation: rootMutation
       });
       const source = request.body.query || request.body.mutation || '';
       const variableValues = request.body.variables || {};

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -4,6 +4,8 @@ import { rootMutation } from './mutation';
 import { rootQuery } from './query';
 import { graphqlBodySchema } from './schema';
 import depthLimit = require('graphql-depth-limit');
+import { Context } from './types/context';
+import { createLoaders } from './loaders';
 
 const DEPTH_LIMIT = 3;
 
@@ -24,7 +26,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       });
       const source = request.body.query || request.body.mutation || '';
       const variableValues = request.body.variables || {};
-      const contextValue = fastify;
+      const contextValue: Context = { fastify, ...createLoaders(fastify.db) };
       const validationErrors = validate(schema, parse(source), [depthLimit(DEPTH_LIMIT)]);
 
       if(validationErrors.length) {

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,4 +1,6 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
+import { graphql, GraphQLSchema } from 'graphql';
+import { rootQuery } from './query';
 import { graphqlBodySchema } from './schema';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
@@ -11,7 +13,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: graphqlBodySchema,
       },
     },
-    async function (request, reply) {}
+    async function (request, reply) {
+      const schema = new GraphQLSchema({
+        query: rootQuery,
+      });
+      const source = request.body.query || request.body.mutation || '';
+      // const variableValues = request.body.variables || {};
+      const contextValue = fastify;
+
+      return await graphql({ schema, source, contextValue });
+    },
   );
 };
 

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,8 +1,11 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { graphql, GraphQLSchema } from 'graphql';
+import { graphql, GraphQLSchema, parse, validate } from 'graphql';
 import { rootMutation } from './mutation';
 import { rootQuery } from './query';
 import { graphqlBodySchema } from './schema';
+import depthLimit = require('graphql-depth-limit');
+
+const DEPTH_LIMIT = 3;
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -22,6 +25,11 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       const source = request.body.query || request.body.mutation || '';
       const variableValues = request.body.variables || {};
       const contextValue = fastify;
+      const validationErrors = validate(schema, parse(source), [depthLimit(DEPTH_LIMIT)]);
+
+      if(validationErrors.length) {
+        reply.send({errors: validationErrors});
+      }
 
       return await graphql({ schema, source, variableValues, contextValue });
     },

--- a/src/routes/graphql/loaders.ts
+++ b/src/routes/graphql/loaders.ts
@@ -1,0 +1,94 @@
+import DataLoader = require('dataloader');
+import DB from "../../utils/DB/DB";
+
+const createMemeberTypeLoader = (db: DB) => {
+  const batchFn = async (ids:Readonly<string[]>) => {
+    const memberTypes = await db.memberTypes.findMany({ key: "id", equalsAnyOf: [...ids] });
+
+    return ids.map((id) => memberTypes.find((memberType) => memberType.id === id) ?? null);
+  }
+
+  return new DataLoader(batchFn);
+};
+
+const createPostLoader = (db: DB) => {
+  const batchFn = async (ids:Readonly<string[]>) => {
+    const posts = await db.posts.findMany({ key: "id", equalsAnyOf: [...ids] });
+
+    return ids.map((id) => posts.find((post) => post.id === id) ?? null);
+  }
+
+  return new DataLoader(batchFn);
+};
+
+const createProfileLoader = (db: DB) => {
+  const batchFn = async (ids:Readonly<string[]>) => {
+    const profiles = await db.profiles.findMany({ key: "id", equalsAnyOf: [...ids] });
+
+    return ids.map((id) => profiles.find((profile) => profile.id === id) ?? null);
+  }
+
+  return new DataLoader(batchFn);
+};
+
+const createUserLoader = (db: DB) => {
+  const batchFn = async (ids:Readonly<string[]>) => {
+    const users = await db.users.findMany({ key: "id", equalsAnyOf: [...ids] });
+
+    return ids.map((id) => users.find((users) => users.id === id) ?? null);
+  }
+
+  return new DataLoader(batchFn);
+};
+
+
+const createProfileByUserIdLoader = (db: DB) => {
+  const batchFn = async (userIds:Readonly<string[]>) => {
+    const profiles = await db.profiles.findMany({ key: "userId", equalsAnyOf: [...userIds] });
+
+    return userIds.map((userId) => profiles.find((profile) => profile.userId === userId) ?? null);
+  }
+
+  return new DataLoader(batchFn);
+};
+
+const createPostsByUserIdLoader = (db: DB) => {
+  const batchFn = async (userIds:Readonly<string[]>) => {
+    const posts = await db.posts.findMany({ key: "userId", equalsAnyOf: [...userIds] });
+
+    return userIds.map((userId) => posts.filter((post) => post.userId === userId) ?? null);
+  }
+
+  return new DataLoader(batchFn);
+};
+
+const createSubscriptionsByUserIdLoader = (db: DB) => {
+  const batchFn = async (userIds:Readonly<string[]>) => {
+    const users = await db.users.findMany({ key: "subscribedToUserIds", inArrayAnyOf: [...userIds] });
+
+    return userIds.map((userId) => users.filter((user) => user.subscribedToUserIds.includes(userId)) ?? null);
+  }
+
+  return new DataLoader(batchFn);
+};
+
+export function createLoaders(db: DB) {
+
+  const memberTypeLoader = createMemeberTypeLoader(db);
+  const postLoader = createPostLoader(db);
+  const profileLoader = createProfileLoader(db);
+  const userLoader = createUserLoader(db);
+  const profileByUserIdLoader = createProfileByUserIdLoader(db);
+  const postsByUserIdLoader = createPostsByUserIdLoader(db);
+  const subscriptionsByUserIdLoader = createSubscriptionsByUserIdLoader(db);
+
+  return {
+    memberTypeLoader,
+    postLoader,
+    userLoader,
+    profileLoader,
+    profileByUserIdLoader,
+    postsByUserIdLoader,
+    subscriptionsByUserIdLoader,
+  };
+}

--- a/src/routes/graphql/mutation.ts
+++ b/src/routes/graphql/mutation.ts
@@ -1,6 +1,6 @@
-import { FastifyInstance } from 'fastify';
 import { GraphQLID, GraphQLNonNull, GraphQLObjectType } from 'graphql';
 import { GraphQLPost, GraphQLCreatePostInput, GraphQLUser, GraphQLCreateUserInput, GraphQLCreateProfileInput, GraphQLProfile, GraphQLUpdateUserInput, GraphQLUpdateProfileInput, GraphQLUpdatePostInput, GraphQLMemberType, GraphQLUpdateMemberTypeInput, GraphQLUserIdInput } from './types';
+import { Context } from './types/context';
 
 export const rootMutation = new GraphQLObjectType({
   name: 'RootMutation',
@@ -10,8 +10,8 @@ export const rootMutation = new GraphQLObjectType({
       args: {
         user: { type: new GraphQLNonNull(GraphQLCreateUserInput) }
       },
-      resolve: async (source, { user }, contextValue: FastifyInstance) => {
-        return await contextValue.db.users.create(user);
+      resolve: async (source, { user }, context: Context) => {
+        return await context.fastify.db.users.create(user);
       },
     },
     createProfile: {
@@ -19,8 +19,8 @@ export const rootMutation = new GraphQLObjectType({
       args: {
         profile: { type: new GraphQLNonNull(GraphQLCreateProfileInput) }
       },
-      resolve: async (source, { profile }, contextValue: FastifyInstance) => {
-        return await contextValue.db.profiles.create(profile);
+      resolve: async (source, { profile }, context: Context) => {
+        return await context.fastify.db.profiles.create(profile);
       },
     },
     createPost: {
@@ -28,8 +28,8 @@ export const rootMutation = new GraphQLObjectType({
       args: {
         post: { type: new GraphQLNonNull(GraphQLCreatePostInput) }
       },
-      resolve: async (source, { post }, contextValue: FastifyInstance) => {
-        return await contextValue.db.posts.create(post);
+      resolve: async (source, { post }, context: Context) => {
+        return await context.fastify.db.posts.create(post);
       },
     },
     updateUser: {
@@ -40,14 +40,14 @@ export const rootMutation = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLUpdateUserInput),
         },
       },
-      resolve: async (source, { id, user }, contextValue: FastifyInstance) => {
+      resolve: async (source, { id, user }, context: Context) => {
         try {
           console.log({ id, user });
         
-          return await contextValue.db.users.change(id, user);
+          return await context.fastify.db.users.change(id, user);
         }
         catch (e) {
-          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+          throw context.fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
         }
       },
     },
@@ -59,13 +59,13 @@ export const rootMutation = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLUpdateProfileInput),
         },
       },
-      resolve: async (source, { id, profile }, contextValue: FastifyInstance) => {
+      resolve: async (source, { id, profile }, context: Context) => {
         try {
         
-          return await contextValue.db.profiles.change(id, profile);
+          return await context.fastify.db.profiles.change(id, profile);
         }
         catch (e) {
-          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+          throw context.fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
         }
       },
     },
@@ -77,13 +77,13 @@ export const rootMutation = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLUpdatePostInput),
         },
       },
-      resolve: async (source, { id, post }, contextValue: FastifyInstance) => {
+      resolve: async (source, { id, post }, context: Context) => {
         try {
         
-          return await contextValue.db.posts.change(id, post);
+          return await context.fastify.db.posts.change(id, post);
         }
         catch (e) {
-          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+          throw context.fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
         }
       },
     },
@@ -95,13 +95,13 @@ export const rootMutation = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLUpdateMemberTypeInput),
         },
       },
-      resolve: async (source, { id, memberType }, contextValue: FastifyInstance) => {
+      resolve: async (source, { id, memberType }, context: Context) => {
         try {
         
-          return await contextValue.db.memberTypes.change(id, memberType);
+          return await context.fastify.db.memberTypes.change(id, memberType);
         }
         catch (e) {
-          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+          throw context.fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
         }
       },
     },
@@ -113,15 +113,15 @@ export const rootMutation = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLUserIdInput),
         },
       },
-      resolve: async (source, { id, subscribeToUser }, contextValue: FastifyInstance) => {
+      resolve: async (source, { id, subscribeToUser }, context: Context) => {
         if (id === subscribeToUser.id) {
-          throw contextValue.httpErrors.badRequest('User cannot subscribe to himself');
+          throw context.fastify.httpErrors.badRequest('User cannot subscribe to himself');
         }
 
-        const user = await contextValue.db.users.findOne({ key: 'id', equals: subscribeToUser.id});
+        const user = await context.fastify.db.users.findOne({ key: 'id', equals: subscribeToUser.id});
 
         if (!user) {
-          throw contextValue.httpErrors.badRequest('User not found');
+          throw context.fastify.httpErrors.badRequest('User not found');
         }
 
         if (user.subscribedToUserIds.includes(id)) {
@@ -132,9 +132,9 @@ export const rootMutation = new GraphQLObjectType({
         
         try {
 
-          return await contextValue.db.users.change(subscribeToUser.id, { subscribedToUserIds: user.subscribedToUserIds });
+          return await context.fastify.db.users.change(subscribeToUser.id, { subscribedToUserIds: user.subscribedToUserIds });
         } catch (e) {
-          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+          throw context.fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
         }
       },
 
@@ -147,20 +147,20 @@ export const rootMutation = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLUserIdInput),
         },
       },
-      resolve: async (source, { id, unsubscribeFromUser }, contextValue: FastifyInstance) => {
-        const user = await contextValue.db.users.findOne({ key: 'id', equals: unsubscribeFromUser.id});
+      resolve: async (source, { id, unsubscribeFromUser }, context: Context) => {
+        const user = await context.fastify.db.users.findOne({ key: 'id', equals: unsubscribeFromUser.id});
 
         if (!user) {
-          throw contextValue.httpErrors.badRequest('User not found');
+          throw context.fastify.httpErrors.badRequest('User not found');
         }
         if (!user.subscribedToUserIds.includes(id)) {
-          throw contextValue.httpErrors.badRequest('User hasn`t this subscription');
+          throw context.fastify.httpErrors.badRequest('User hasn`t this subscription');
         }
         try {
     
-          return await contextValue.db.users.change(unsubscribeFromUser.id, { subscribedToUserIds: user.subscribedToUserIds.filter((subscriberId) => subscriberId !== id) });
+          return await context.fastify.db.users.change(unsubscribeFromUser.id, { subscribedToUserIds: user.subscribedToUserIds.filter((subscriberId) => subscriberId !== id) });
         } catch (e) {
-          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+          throw context.fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
         }
       },
     },

--- a/src/routes/graphql/mutation.ts
+++ b/src/routes/graphql/mutation.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
-import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
-import { GraphQLPost, GraphQLCreatePostInput, GraphQLUser, GraphQLCreateUserInput, GraphQLCreateProfileInput, GraphQLProfile } from './types';
+import { GraphQLID, GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLPost, GraphQLCreatePostInput, GraphQLUser, GraphQLCreateUserInput, GraphQLCreateProfileInput, GraphQLProfile, GraphQLUpdateUserInput, GraphQLUpdateProfileInput, GraphQLUpdatePostInput, GraphQLMemberType, GraphQLUpdateMemberTypeInput, GraphQLUserIdInput } from './types';
 
 export const rootMutation = new GraphQLObjectType({
   name: 'RootMutation',
@@ -30,6 +30,138 @@ export const rootMutation = new GraphQLObjectType({
       },
       resolve: async (source, { post }, contextValue: FastifyInstance) => {
         return await contextValue.db.posts.create(post);
+      },
+    },
+    updateUser: {
+      type: GraphQLUser,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        user: {
+          type: new GraphQLNonNull(GraphQLUpdateUserInput),
+        },
+      },
+      resolve: async (source, { id, user }, contextValue: FastifyInstance) => {
+        try {
+          console.log({ id, user });
+        
+          return await contextValue.db.users.change(id, user);
+        }
+        catch (e) {
+          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+        }
+      },
+    },
+    updateProfile: {
+      type: GraphQLProfile,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        profile: {
+          type: new GraphQLNonNull(GraphQLUpdateProfileInput),
+        },
+      },
+      resolve: async (source, { id, profile }, contextValue: FastifyInstance) => {
+        try {
+        
+          return await contextValue.db.profiles.change(id, profile);
+        }
+        catch (e) {
+          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+        }
+      },
+    },
+    updatePost: {
+      type: GraphQLPost,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        post: {
+          type: new GraphQLNonNull(GraphQLUpdatePostInput),
+        },
+      },
+      resolve: async (source, { id, post }, contextValue: FastifyInstance) => {
+        try {
+        
+          return await contextValue.db.posts.change(id, post);
+        }
+        catch (e) {
+          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+        }
+      },
+    },
+    updateMemberType: {
+      type: GraphQLMemberType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        memberType: {
+          type: new GraphQLNonNull(GraphQLUpdateMemberTypeInput),
+        },
+      },
+      resolve: async (source, { id, memberType }, contextValue: FastifyInstance) => {
+        try {
+        
+          return await contextValue.db.memberTypes.change(id, memberType);
+        }
+        catch (e) {
+          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+        }
+      },
+    },
+    subscribeTo: {
+      type: GraphQLUser,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        subscribeToUser: {
+          type: new GraphQLNonNull(GraphQLUserIdInput),
+        },
+      },
+      resolve: async (source, { id, subscribeToUser }, contextValue: FastifyInstance) => {
+        if (id === subscribeToUser.id) {
+          throw contextValue.httpErrors.badRequest('User cannot subscribe to himself');
+        }
+
+        const user = await contextValue.db.users.findOne({ key: 'id', equals: subscribeToUser.id});
+
+        if (!user) {
+          throw contextValue.httpErrors.badRequest('User not found');
+        }
+
+        if (user.subscribedToUserIds.includes(id)) {
+
+          return user;
+        }
+        user.subscribedToUserIds.push(id);
+        
+        try {
+
+          return await contextValue.db.users.change(subscribeToUser.id, { subscribedToUserIds: user.subscribedToUserIds });
+        } catch (e) {
+          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+        }
+      },
+
+    },
+    unsubscribeFrom: {
+      type: GraphQLUser,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        unsubscribeFromUser: {
+          type: new GraphQLNonNull(GraphQLUserIdInput),
+        },
+      },
+      resolve: async (source, { id, unsubscribeFromUser }, contextValue: FastifyInstance) => {
+        const user = await contextValue.db.users.findOne({ key: 'id', equals: unsubscribeFromUser.id});
+
+        if (!user) {
+          throw contextValue.httpErrors.badRequest('User not found');
+        }
+        if (!user.subscribedToUserIds.includes(id)) {
+          throw contextValue.httpErrors.badRequest('User hasn`t this subscription');
+        }
+        try {
+    
+          return await contextValue.db.users.change(unsubscribeFromUser.id, { subscribedToUserIds: user.subscribedToUserIds.filter((subscriberId) => subscriberId !== id) });
+        } catch (e) {
+          throw contextValue.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+        }
       },
     },
   },

--- a/src/routes/graphql/mutation.ts
+++ b/src/routes/graphql/mutation.ts
@@ -1,0 +1,36 @@
+import { FastifyInstance } from 'fastify';
+import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { GraphQLPost, GraphQLCreatePostInput, GraphQLUser, GraphQLCreateUserInput, GraphQLCreateProfileInput, GraphQLProfile } from './types';
+
+export const rootMutation = new GraphQLObjectType({
+  name: 'RootMutation',
+  fields: {
+    createUser: {
+      type: GraphQLUser,
+      args: {
+        user: { type: new GraphQLNonNull(GraphQLCreateUserInput) }
+      },
+      resolve: async (source, { user }, contextValue: FastifyInstance) => {
+        return await contextValue.db.users.create(user);
+      },
+    },
+    createProfile: {
+      type: GraphQLProfile,
+      args: {
+        profile: { type: new GraphQLNonNull(GraphQLCreateProfileInput) }
+      },
+      resolve: async (source, { profile }, contextValue: FastifyInstance) => {
+        return await contextValue.db.profiles.create(profile);
+      },
+    },
+    createPost: {
+      type: GraphQLPost,
+      args: {
+        post: { type: new GraphQLNonNull(GraphQLCreatePostInput) }
+      },
+      resolve: async (source, { post }, contextValue: FastifyInstance) => {
+        return await contextValue.db.posts.create(post);
+      },
+    },
+  },
+});

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -1,20 +1,32 @@
-import { GraphQLList, GraphQLObjectType } from "graphql";
-import { GraphQLMemberType, GraphQLPost, GraphQLProfile, GraphQLUser } from "./types";
-import {FastifyInstance} from "fastify";
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+import {
+  GraphQLMemberType,
+  GraphQLPost,
+  GraphQLProfile,
+  GraphQLUser,
+} from './types';
+import { FastifyInstance } from 'fastify';
 
 export const rootQuery = new GraphQLObjectType({
   name: 'RootQuery',
   fields: {
-    memberTypes: { type: new GraphQLList(GraphQLMemberType),
+    memberTypes: {
+      type: new GraphQLList(GraphQLMemberType),
       resolve: async (source, args, contextValue: FastifyInstance) => {
 
         return contextValue.db.memberTypes.findMany();
       },
     },
-    posts: { type: new GraphQLList(GraphQLPost),
+    posts: {
+      type: new GraphQLList(GraphQLPost),
       resolve: async (source, args, contextValue: FastifyInstance) => {
 
-        return await contextValue.db.posts.findMany()
+        return await contextValue.db.posts.findMany();
       },
     },
     profiles: { type: new GraphQLList(GraphQLProfile),
@@ -28,6 +40,78 @@ export const rootQuery = new GraphQLObjectType({
 
         return await contextValue.db.users.findMany()
       }
+    },
+    memberType: {
+      type: GraphQLMemberType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve: async (source, { id }, contextValue: FastifyInstance) => {
+        const memberType = await contextValue.db.memberTypes.findOne({
+          key: 'id',
+          equals: id,
+        });
+
+        if (!memberType) {
+          throw contextValue.httpErrors.notFound('Member type not found');
+        }
+
+        return memberType;
+      },
+    },
+    post: {
+      type: GraphQLPost,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve: async (source, { id }, contextValue: FastifyInstance) => {
+        const post = await contextValue.db.posts.findOne({
+          key: 'id',
+          equals: id,
+        });
+
+        if (!post) {
+          throw contextValue.httpErrors.notFound('Post not found');
+        }
+
+        return post;
+      },
+    },
+    profile: {
+      type: GraphQLProfile,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve: async (source, { id }, contextValue: FastifyInstance) => {
+        const profile = await contextValue.db.profiles.findOne({
+          key: 'id',
+          equals: id,
+        });
+
+        if (!profile) {
+          throw contextValue.httpErrors.notFound('Profile not found');
+        }
+
+        return profile;
+      },
+    },
+    user: {
+      type: GraphQLUser,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve: async (source, { id }, contextValue: FastifyInstance) => {
+        const user = await contextValue.db.users.findOne({
+          key: 'id',
+          equals: id,
+        });
+
+        if (!user) {
+          throw contextValue.httpErrors.notFound('User not found');
+        }
+
+        return user;
+      },
     },
   },
 });

--- a/src/routes/graphql/query.ts
+++ b/src/routes/graphql/query.ts
@@ -1,0 +1,33 @@
+import { GraphQLList, GraphQLObjectType } from "graphql";
+import { GraphQLMemberType, GraphQLPost, GraphQLProfile, GraphQLUser } from "./types";
+import {FastifyInstance} from "fastify";
+
+export const rootQuery = new GraphQLObjectType({
+  name: 'RootQuery',
+  fields: {
+    memberTypes: { type: new GraphQLList(GraphQLMemberType),
+      resolve: async (source, args, contextValue: FastifyInstance) => {
+
+        return contextValue.db.memberTypes.findMany();
+      },
+    },
+    posts: { type: new GraphQLList(GraphQLPost),
+      resolve: async (source, args, contextValue: FastifyInstance) => {
+
+        return await contextValue.db.posts.findMany()
+      },
+    },
+    profiles: { type: new GraphQLList(GraphQLProfile),
+      resolve: async (source, args, contextValue: FastifyInstance) => {
+
+        return await contextValue.db.profiles.findMany()
+      },
+    },
+    users: { type: new GraphQLList(GraphQLUser),
+      resolve: async (source, args, contextValue: FastifyInstance) => {
+
+        return await contextValue.db.users.findMany()
+      }
+    },
+  },
+});

--- a/src/routes/graphql/types.ts
+++ b/src/routes/graphql/types.ts
@@ -40,18 +40,7 @@ export const GraphQLProfile = new GraphQLObjectType({
   }),
 });
 
-export const GraphQLBasicUser = new GraphQLObjectType({
-  name: 'BasicUser',
-  fields: () => ({
-    id: { type: GraphQLString },
-    firstName: { type: GraphQLString },
-    lastName: { type: GraphQLString },
-    email: { type: GraphQLString },
-    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
-  })
-,});
-
-export const GraphQLUser = new GraphQLObjectType({
+export const GraphQLUser: GraphQLObjectType = new GraphQLObjectType({
   name: 'User',
   fields: () => ({
     id: { type: GraphQLString },
@@ -85,9 +74,17 @@ export const GraphQLUser = new GraphQLObjectType({
       }
     },
     userSubscribedTo: {
-      type: new GraphQLList(GraphQLBasicUser),
+      type: new GraphQLList(GraphQLUser),
       resolve: async (user, args, contextValue: FastifyInstance) => {
         return await contextValue.db.users.findMany({key: 'subscribedToUserIds', inArray: user.id});
+      }
+    },
+    subscribedToUser: {
+      type: new GraphQLList(GraphQLUser),
+      resolve: async (user, args, contextValue: FastifyInstance) => {
+        return user.subscribedToUserIds.map(async (id: string) => {
+          return await contextValue.db.users.findOne({key: 'id', equals: id});
+        })
       }
     },
   }),

--- a/src/routes/graphql/types.ts
+++ b/src/routes/graphql/types.ts
@@ -1,0 +1,51 @@
+import {
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+export const GraphQLMemberType = new GraphQLObjectType({
+  name: 'GraphQLMemberType',
+  fields: () => ({
+    id: { type: GraphQLString },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  }),
+});
+
+export const GraphQLPost = new GraphQLObjectType({
+  name: 'Post',
+  fields: () => ({
+    id: { type: GraphQLString },
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+    userId: { type: GraphQLString },
+  }),
+});
+
+export const GraphQLProfile = new GraphQLObjectType({
+  name: 'Profile',
+  fields: () => ({
+    id: { type: GraphQLString },
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    userId: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+  }),
+});
+
+export const GraphQLUser = new GraphQLObjectType({
+  name: 'User',
+  fields: () => ({
+    id: { type: GraphQLString },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+  }),
+});

--- a/src/routes/graphql/types.ts
+++ b/src/routes/graphql/types.ts
@@ -1,3 +1,4 @@
+import { FastifyInstance } from 'fastify';
 import {
   GraphQLInt,
   GraphQLList,
@@ -47,5 +48,30 @@ export const GraphQLUser = new GraphQLObjectType({
     lastName: { type: GraphQLString },
     email: { type: GraphQLString },
     subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+    posts: {
+      type: new GraphQLList(GraphQLPost),
+      resolve: async (user, args, contextValue: FastifyInstance) => {
+        return await contextValue.db.posts.findMany({key: 'userId', equals: user.id});
+      }
+    },
+    profile: {
+      type: GraphQLProfile,
+      resolve: async (user, args, contextValue: FastifyInstance) => {
+        return await contextValue.db.profiles.findOne({key: 'userId', equals: user.id});
+      }
+    },
+    memberType: {
+      type: GraphQLMemberType,
+      resolve: async (user, args, contextValue: FastifyInstance) => {
+        const profile = await contextValue.db.profiles.findOne({key: 'userId', equals: user.id});
+
+        if (!profile) {
+
+          return Promise.resolve(null);
+        }
+
+        return await contextValue.db.memberTypes.findOne({key: 'id', equals: profile.memberTypeId});
+      }
+    }
   }),
 });

--- a/src/routes/graphql/types.ts
+++ b/src/routes/graphql/types.ts
@@ -40,6 +40,17 @@ export const GraphQLProfile = new GraphQLObjectType({
   }),
 });
 
+export const GraphQLBasicUser = new GraphQLObjectType({
+  name: 'BasicUser',
+  fields: () => ({
+    id: { type: GraphQLString },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+  })
+,});
+
 export const GraphQLUser = new GraphQLObjectType({
   name: 'User',
   fields: () => ({
@@ -72,6 +83,12 @@ export const GraphQLUser = new GraphQLObjectType({
 
         return await contextValue.db.memberTypes.findOne({key: 'id', equals: profile.memberTypeId});
       }
-    }
+    },
+    userSubscribedTo: {
+      type: new GraphQLList(GraphQLBasicUser),
+      resolve: async (user, args, contextValue: FastifyInstance) => {
+        return await contextValue.db.users.findMany({key: 'subscribedToUserIds', inArray: user.id});
+      }
+    },
   }),
 });

--- a/src/routes/graphql/types/context.ts
+++ b/src/routes/graphql/types/context.ts
@@ -1,0 +1,6 @@
+import { FastifyInstance } from 'fastify';
+import { createLoaders } from '../loaders';
+
+export type Context = ReturnType<typeof createLoaders> & {
+  fastify: FastifyInstance;
+};

--- a/src/routes/graphql/types/index.ts
+++ b/src/routes/graphql/types/index.ts
@@ -1,0 +1,4 @@
+export * from './memberType';
+export * from './post';
+export * from './profile';
+export * from './user';

--- a/src/routes/graphql/types/memberType.ts
+++ b/src/routes/graphql/types/memberType.ts
@@ -1,0 +1,14 @@
+import {
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+export const GraphQLMemberType = new GraphQLObjectType({
+  name: 'GraphQLMemberType',
+  fields: () => ({
+    id: { type: GraphQLString },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  }),
+});

--- a/src/routes/graphql/types/memberType.ts
+++ b/src/routes/graphql/types/memberType.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLInputObjectType,
   GraphQLInt,
   GraphQLObjectType,
   GraphQLString,
@@ -8,6 +9,14 @@ export const GraphQLMemberType = new GraphQLObjectType({
   name: 'GraphQLMemberType',
   fields: () => ({
     id: { type: GraphQLString },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  }),
+});
+
+export const GraphQLUpdateMemberTypeInput = new GraphQLInputObjectType({
+  name: 'UpdateMemberTypeInput',
+  fields: () => ({
     discount: { type: GraphQLInt },
     monthPostsLimit: { type: GraphQLInt },
   }),

--- a/src/routes/graphql/types/post.ts
+++ b/src/routes/graphql/types/post.ts
@@ -1,4 +1,6 @@
 import {
+  GraphQLInputObjectType,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
@@ -10,5 +12,14 @@ export const GraphQLPost = new GraphQLObjectType({
     title: { type: GraphQLString },
     content: { type: GraphQLString },
     userId: { type: GraphQLString },
+  }),
+});
+
+export const GraphQLCreatePostInput = new GraphQLInputObjectType({
+  name: 'CreatePostInput',
+  fields: () => ({
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type: new GraphQLNonNull(GraphQLString) },
   }),
 });

--- a/src/routes/graphql/types/post.ts
+++ b/src/routes/graphql/types/post.ts
@@ -23,3 +23,11 @@ export const GraphQLCreatePostInput = new GraphQLInputObjectType({
     content: { type: new GraphQLNonNull(GraphQLString) },
   }),
 });
+
+export const GraphQLUpdatePostInput = new GraphQLInputObjectType({
+  name: 'UpdatePostInput',
+  fields: () => ({
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+  }),
+});

--- a/src/routes/graphql/types/post.ts
+++ b/src/routes/graphql/types/post.ts
@@ -1,0 +1,14 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+export const GraphQLPost = new GraphQLObjectType({
+  name: 'Post',
+  fields: () => ({
+    id: { type: GraphQLString },
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+    userId: { type: GraphQLString },
+  }),
+});

--- a/src/routes/graphql/types/profile.ts
+++ b/src/routes/graphql/types/profile.ts
@@ -1,0 +1,20 @@
+import {
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
+
+export const GraphQLProfile = new GraphQLObjectType({
+  name: 'Profile',
+  fields: () => ({
+    id: { type: GraphQLString },
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    userId: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+  }),
+});

--- a/src/routes/graphql/types/profile.ts
+++ b/src/routes/graphql/types/profile.ts
@@ -35,3 +35,16 @@ export const GraphQLCreateProfileInput = new GraphQLInputObjectType({
     memberTypeId: { type: new GraphQLNonNull(GraphQLString) },
   }),
 });
+
+export const GraphQLUpdateProfileInput = new GraphQLInputObjectType({
+  name: 'UpdateProfileInput',
+  fields: () => ({
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+  }),
+});

--- a/src/routes/graphql/types/profile.ts
+++ b/src/routes/graphql/types/profile.ts
@@ -1,5 +1,8 @@
 import {
+  GraphQLID,
+  GraphQLInputObjectType,
   GraphQLInt,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
@@ -16,5 +19,19 @@ export const GraphQLProfile = new GraphQLObjectType({
     city: { type: GraphQLString },
     userId: { type: GraphQLString },
     memberTypeId: { type: GraphQLString },
+  }),
+});
+
+export const GraphQLCreateProfileInput = new GraphQLInputObjectType({
+  name: 'CreateProfileInput',
+  fields: () => ({
+    avatar: { type: new GraphQLNonNull(GraphQLString) },
+    sex: { type: new GraphQLNonNull(GraphQLString) },
+    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    street: { type: new GraphQLNonNull(GraphQLString) },
+    city: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLID) },
+    memberTypeId: { type: new GraphQLNonNull(GraphQLString) },
   }),
 });

--- a/src/routes/graphql/types/user.ts
+++ b/src/routes/graphql/types/user.ts
@@ -1,44 +1,10 @@
 import { FastifyInstance } from 'fastify';
 import {
-  GraphQLInt,
   GraphQLList,
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
-
-export const GraphQLMemberType = new GraphQLObjectType({
-  name: 'GraphQLMemberType',
-  fields: () => ({
-    id: { type: GraphQLString },
-    discount: { type: GraphQLInt },
-    monthPostsLimit: { type: GraphQLInt },
-  }),
-});
-
-export const GraphQLPost = new GraphQLObjectType({
-  name: 'Post',
-  fields: () => ({
-    id: { type: GraphQLString },
-    title: { type: GraphQLString },
-    content: { type: GraphQLString },
-    userId: { type: GraphQLString },
-  }),
-});
-
-export const GraphQLProfile = new GraphQLObjectType({
-  name: 'Profile',
-  fields: () => ({
-    id: { type: GraphQLString },
-    avatar: { type: GraphQLString },
-    sex: { type: GraphQLString },
-    birthday: { type: GraphQLInt },
-    country: { type: GraphQLString },
-    street: { type: GraphQLString },
-    city: { type: GraphQLString },
-    userId: { type: GraphQLString },
-    memberTypeId: { type: GraphQLString },
-  }),
-});
+import { GraphQLMemberType, GraphQLPost, GraphQLProfile } from '.';
 
 export const GraphQLUser: GraphQLObjectType = new GraphQLObjectType({
   name: 'User',

--- a/src/routes/graphql/types/user.ts
+++ b/src/routes/graphql/types/user.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify';
 import {
+  GraphQLInputObjectType,
   GraphQLList,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
@@ -55,3 +57,13 @@ export const GraphQLUser: GraphQLObjectType = new GraphQLObjectType({
     },
   }),
 });
+
+export const GraphQLCreateUserInput = new GraphQLInputObjectType({
+  name: 'CreateUserInput',
+  fields: () => ({
+    firstName: { type: new GraphQLNonNull(GraphQLString) },
+    lastName: { type: new GraphQLNonNull(GraphQLString) },
+    email: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+

--- a/src/routes/graphql/types/user.ts
+++ b/src/routes/graphql/types/user.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import {
+  GraphQLID,
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
@@ -67,3 +68,19 @@ export const GraphQLCreateUserInput = new GraphQLInputObjectType({
   }),
 });
 
+export const GraphQLUpdateUserInput = new GraphQLInputObjectType({
+  name: 'UpdateUserInput',
+  fields: () => ({
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+  }),
+});
+
+export const GraphQLUserIdInput = new GraphQLInputObjectType({
+  name: 'UserIdInput',
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLID) },
+  }),
+});

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -6,9 +6,11 @@ import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
-    MemberTypeEntity[]
-  > {});
+  fastify.get('/', async function (request, reply): Promise<MemberTypeEntity[]> {
+
+    return fastify.db.memberTypes.findMany();
+  }
+  );
 
   fastify.get(
     '/:id',
@@ -17,7 +19,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const memberType = await fastify.db.memberTypes.findOne({ key: 'id', equals: request.params.id});
+
+      if (!memberType) {
+          throw fastify.httpErrors.notFound('Member type not found');
+      }
+
+      return memberType;
+    }
   );
 
   fastify.patch(
@@ -28,7 +38,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      try {
+        
+        return await fastify.db.memberTypes.change(request.params.id, request.body);
+      }
+      catch (e) {
+        throw fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+      }
+    }
   );
 };
 

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -6,7 +6,10 @@ import type { PostEntity } from '../../utils/DB/entities/DBPosts';
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {
+
+    return await fastify.db.posts.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -15,7 +18,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      const post = await fastify.db.posts.findOne({key: 'id', equals: request.params.id});
+
+      if (!post) {
+        throw fastify.httpErrors.notFound('Post not found');
+      }
+
+      return post;
+    }
   );
 
   fastify.post(
@@ -25,7 +36,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createPostBodySchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+
+      return await fastify.db.posts.create(request.body);
+    }
   );
 
   fastify.delete(
@@ -35,7 +49,14 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      try {
+
+        return await fastify.db.posts.delete(request.params.id);
+      } catch (e) {
+        throw fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+      }
+    }
   );
 
   fastify.patch(
@@ -46,7 +67,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      try {
+        
+        return await fastify.db.posts.change(request.params.id, request.body);
+      }
+      catch (e) {
+        throw fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+      }
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -10,7 +10,10 @@ import type { UserEntity } from '../../utils/DB/entities/DBUsers';
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {
+
+    return fastify.db.users.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -19,7 +22,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await fastify.db.users.findOne({key: 'id', equals: request.params.id});
+
+      if (!user) {
+        throw fastify.httpErrors.notFound('User not found');
+      }
+
+      return user;
+    }
   );
 
   fastify.post(
@@ -29,7 +40,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createUserBodySchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+
+      return await fastify.db.users.create(request.body);
+    }
   );
 
   fastify.delete(
@@ -39,7 +53,24 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await fastify.db.users.findOne({ key: 'id', equals: request.params.id });
+
+      if (!user) {
+          throw fastify.httpErrors.badRequest('User not found');
+      }
+      (await fastify.db.posts.findMany({ key: 'userId', equals: request.params.id})).forEach(async (post) => {
+        await fastify.db.posts.delete(post.id);
+      });
+      const profile = await fastify.db.profiles.findOne({ key: 'userId', equals: request.params.id});
+      if (profile) {
+        await fastify.db.profiles.delete(profile.id);
+      }
+      (await fastify.db.users.findMany({ key: 'subscribedToUserIds', inArray: request.params.id })).forEach(async (subscriber) => {
+        await fastify.db.users.change(subscriber.id, { subscribedToUserIds: subscriber.subscribedToUserIds.filter((id) => id !== request.params.id) });
+      });
+      return await fastify.db.users.delete(request.params.id);
+    }
   );
 
   fastify.post(
@@ -50,19 +81,61 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      if (request.params.id === request.body.userId) {
+          throw fastify.httpErrors.badRequest('User cannot subscribe to himself');
+      }
+
+      const user = await fastify.db.users.findOne({ key: 'id', equals: request.body.userId});
+
+      if (!user) {
+        throw fastify.httpErrors.badRequest('User not found');
+      }
+
+      if (user.subscribedToUserIds.includes(request.params.id)) {
+
+        return user;
+      }
+      user.subscribedToUserIds.push(request.params.id);
+      
+      try {
+
+        return await fastify.db.users.change(request.body.userId, { subscribedToUserIds: user.subscribedToUserIds });
+      } catch (e) {
+        throw fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+      }
+    }
   );
 
   fastify.post(
     '/:id/unsubscribeFrom',
     {
+      
       schema: {
         body: subscribeBodySchema,
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
-  );
+    async function (request, reply): Promise<UserEntity> {
+    const user = await fastify.db.users.findOne({ key: 'id', equals: request.body.userId});
+
+    if (!user) {
+      throw fastify.httpErrors.badRequest('User not found');
+    }
+    if (!user.subscribedToUserIds.includes(request.params.id)) {
+      throw fastify.httpErrors.badRequest('User hasn`t this subscription');
+    }
+    if (request.body.userId === request.params.id) {
+      return user;
+    }
+    try {
+
+      return await fastify.db.users.change(request.body.userId, { subscribedToUserIds: user.subscribedToUserIds.filter((id) => id !== request.params.id) });
+    } catch (e) {
+      throw fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+    }
+  }
+);
 
   fastify.patch(
     '/:id',
@@ -72,7 +145,15 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      try {
+        
+        return await fastify.db.users.change(request.params.id, request.body);
+      }
+      catch (e) {
+        throw fastify.httpErrors.badRequest(e instanceof Error ? e.message : undefined);
+      }
+    }
   );
 };
 


### PR DESCRIPTION
1. Task: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md
2. Deadline 2023-01-31
3. Total score **(360/360)**

## Basic Scope
 * [x]  **+72** Task 1: restful endpoints.
 * [x]  **+72** Subtasks 2.1-2.7: get gql queries.
**Notice**: You can find GraphQL requests collection for Postman in root of this project `node-graphql.postman_collection.json`.

 2.1
query:
```graphql
query {
  memberTypes { id }
  posts { id }
  profiles { id }
  users { id }
}
```
2.2
query:
```graphql
query($memberTypeId: String!, $postId: String!, $profileId: String!, $userId: String!) {
  memberType(id: $memberTypeId){ id }
  post(id: $postId) { id }
  profile(id: $profileId) { id }
  user(id: $userId) { id }
}
```
variables: - input the required id
```json
{
  "memberTypeId": "basic",
  "postId": "", 
  "profileId": "", 
  "userId": ""
}
```
2.3
query:
```graphql
query {
  users {
    id
    posts { id }
    profile { id }
    memberType { id }
  }
}
```
2.4
query:
```graphql
query($id: String!) {
  user(id: $id) {
    id
    posts {id}
    profile {id}
    memberType {id}
  }
}
```
variables: - please input the required id
```json
{
  "id": ""
}
```
2.5.
query:
```graphql
query {
  users {
    id
    userSubscribedTo {id}
    profile {id}
  }
}
```
2.6.
query:
```graphql
query($id: String!) {
  user(id: $id) {
    id
    subscribedToUser {id}
    posts {id}
  }
}
```
variables: - please input the required id
```json
{
  "id": ""
}
```
2.7
query:
```graphql
query {
  users {
    id
    userSubscribedTo {
      id
      userSubscribedTo {id}
      subscribedToUser {id}
    }
    subscribedToUser {
      id
      userSubscribedTo {id}
      subscribedToUser {id}
    }
  }
}
```
 * [x]  **+54** Subtasks 2.8-2.11: create gql queries.
2.8
query:
```graphql
mutation ($user: CreateUserInput!) {
  createUser(user: $user) {
    id
    firstName
    lastName
    email
    subscribedToUserIds
  }
}
```
variables:
```json
{
  "user": {
    "firstName": "Frances",
    "lastName": "Hudson",
    "email": "Carleton_Monahan@gmail.com"
  }
}
```
2.9
query:
```graphql
mutation ($profile: CreateProfileInput!) {
  createProfile(profile: $profile) {
    id
    avatar
    sex
    birthday
    country
    street
    city
    userId
    memberTypeId
  }
}
```
variables: - please input the required id
```json
{
  "profile": {
    "userId": "",
    "memberTypeId": "basic",
    "avatar": 
"https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/758.jpg",
    "sex": "female",
    "birthday": 1200784,
    "country": "Cyprus",
    "street": "Wilber Villages",
    "city": "Beavercreek"
  }
}
```
2.10
query:
```graphql
mutation ($post: CreatePostInput!) {
    createPost(post: $post) {
        id
        userId
        title
        content
    }
}
```
variables: - please input the required id
```json
{
  "post": {
    "userId": "",
    "title": "2_Beatae doloremque nemo aperiam culpa neque dolore reiciendis.",
    "content": "Eligendi pariatur aspernatur nam. Animi beatae deleniti ducimus id numquam\nquidem eligendi. Dolor eius est. Incidunt atque cum velit sit nam commodi. Repudiandae alias ratione similique sunt."
  }
}
```
2.11
![image](https://user-images.githubusercontent.com/96181572/215576987-c259a255-bb2a-489a-bac3-5d1f61b42110.png)

 * [x]  **+54** Subtasks 2.12-2.17: update gql queries.
2.12
query:
```graphql
mutation ($id: ID!, $user: UpdateUserInput!) {
  updateUser(id: $id, user: $user) {
    id
    firstName
    lastName
    email
    subscribedToUserIds
  }
}
```
variables: - please input the required id from application database
```json
{
  "id": "",
  "user": {
    "firstName": "Leonor",
    "lastName": "Leannon",
    "email": "Glen.Huel58@yahoo.com"
  }
}
```
2.13
```graphql
mutation ($id: ID!, $profile: UpdateProfileInput!) {
  updateProfile(id: $id, profile: $profile) {
    id
    avatar
    sex
    birthday
    country
    street
    city
    userId
    memberTypeId
  }
}
```
variables: - please input the required id from application database
```json
{
  "id": "",
  "profile": {
    "memberTypeId": "basic",
    "avatar": 
"https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/758.jpg",
    "sex": "female",
    "birthday": 1200784,
    "country": "Istambul",
    "street": "Wilber Villages",
    "city": "Beavercreek"
  }
}
```
2.14
```graphql
mutation ($id: ID!, $post: UpdatePostInput!) {
  updatePost(id: $id, post: $post) {
    id
    userId
    title
    content
  }
}
```
variables: - please input the required id from application database
```json
{
  "id": "",
  "post": {
    "title": "Laborum possimus sed.",
    "content": "Pariatur eum quisquam distinctio perferendis molestias illo quam. Quos id\ncumque atque suscipit maiores. Mollitia eaque maxime omnis. Esse vitae deleniti consectetur natus. Harum temporibus\nvelit aperiam."
   }
}
```
2.15
```graphql
mutation ($id: ID!, $memberType: UpdateMemberTypeInput!) {
  updateMemberType(id: $id, memberType: $memberType) {
    id
    discount        
    monthPostsLimit
  }
}
```
variables: - please input the required id from application database
```json
{
  "id": "basic",
  "memberType": {
    "discount": 10,
    "monthPostsLimit": 50
  }
}
```
2.16
```graphql
mutation ($id: ID!, $subscribeToUser: UserIdInput!) {
  subscribeTo(id: $id, subscribeToUser: $subscribeToUser){
   id
   subscribedToUserIds
  }
}

```
variables: - please input the required id from application database
```json
{
  "id": "",
  "subscribeToUser": {
    "id": ""
  }
}
```
```graphql
mutation ($id: ID!, $unsubscribeFromUser: UserIdInput!) {
  unsubscribeFrom(id: $id, unsubscribeFromUser: $unsubscribeFromUser){
   id
   subscribedToUserIds
  }
}
```
variables: - please input the required id from application database
```json
{
  "id": "",
  "unsubscribeFromUser": {
    "id": ""
  }
}
```
2.17 `is the same as 2.11`
![image](https://user-images.githubusercontent.com/96181572/215576987-c259a255-bb2a-489a-bac3-5d1f61b42110.png)

 * [x]  **+88** Task 3: solve `n+1` graphql problem.
 Dataloaders logic creation:
 https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/loaders.ts#L1-L94
Creation dataloaders in GQL context:
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/index.ts#L29
Use in resolvers:
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/query.ts#L23
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/query.ts#L33
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/query.ts#L52-L55
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/query.ts#L67
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/query.ts#L82
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/query.ts#L97
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/query.ts#L112
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/types/user.ts#L23
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/types/user.ts#L29
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/types/user.ts#L35
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/types/user.ts#L42
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/types/user.ts#L48
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/types/user.ts#L55

 * [X]  **+20** Task 4: limit the complexity of the graphql queries.
https://github.com/Alexander-M-rss/node-graphql/blob/035164672f598b70a84fdba1d7d1714e60b98c2b/src/routes/graphql/index.ts#L30-L34
 maximum operation depth set to 3. You can change it by const DEPTH_LIMIT in src/routes/graphql/index.ts.
This  query ends with an error :
```graphql
query {
  users {
    id
    userSubscribedTo {
      id
      userSubscribedTo {
        id
        userSubscribedTo {id}
      }
    }
  }
}
```
 
 ## Forfeits
 * [ ]  **-30% of max task score** Commits after deadline (except commits that affect only Readme.md, .gitignore, etc.)
 * [ ]  **-60% of max task score** Samples of POST body for gql requests were not provided for those subtasks that were declared to be completed.
 * [ ]  **-100% of max task score** Tests have been modified.
 * [ ]  **-20** No separate development branch
 * [ ]  **-20** No Pull Request
 * [ ]  **-10** Pull Request description is incorrect
 * [ ]  **-20** Less than 3 commits in the development branch, not including commits that make changes only to `Readme.md` or similar files (`tsconfig.json`, `.gitignore`, `.prettierrc.json`, etc.)
